### PR TITLE
`go get` is no longer supported outside a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To generate the credentials file, please, refer to [this documentation page](htt
 `pigeon` provides the command-line tools.
 
 ```shell
-$ go get github.com/kaneshin/pigeon/cmd/...
+$ go install github.com/kaneshin/pigeon/cmd/pigeon@latest
 ```
 
 Make sure that `pigeon` was installed correctly:

--- a/cmd/pigeon/README.md
+++ b/cmd/pigeon/README.md
@@ -16,7 +16,7 @@ $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service_account.json
 Type the following line to install `pigeon`.
 
 ```shell
-$ go get github.com/kaneshin/pigeon/cmd/pigeon
+$ go install github.com/kaneshin/pigeon/cmd/pigeon@latest
 ```
 
 Make sure that `pigeon` was installed correctly:


### PR DESCRIPTION
In Go 1.17 and beyond, executables outside of a module must be installed using `go install` instead of `go get`. See [Deprecation of 'go get' for installing executables](https://go.dev/doc/go-get-install-deprecation).

```sh
% go get github.com/kaneshin/pigeon/cmd/...
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

In the new command I wrote, you may want to change `github.com/kaneshin/pigeon/cmd/pigeon` to `github.com/kaneshin/pigeon/cmd/...` to install all the utilities, instead of `pigeon` only. This would actually resemble the old command more closely, but I thought about it only after committing (sorry).
